### PR TITLE
Remove current record from queue when ignoring it based on negative timestamp

### DIFF
--- a/core/Processors/Internal/RecordQueue.cs
+++ b/core/Processors/Internal/RecordQueue.cs
@@ -109,6 +109,7 @@ namespace Streamiz.Kafka.Net.Processors.Internal
                         "Skipping record due to negative extracted timestamp. topic=[{Topic}] partition=[{Partition}] offset=[{Offset}] extractedTimestamp=[{Timestamp}] extractor=[{TimestampExtractor}]",
                         record.Topic, record.Partition, record.Offset, timestamp, timestampExtractor.GetType().Name);
                     droppedRecordsSensor.Record();
+                    queue.RemoveAt(0);
                     continue;
                 }
 


### PR DESCRIPTION
In our project we encountered cases when some faulty data is provided in topic.
We wanted to ignore records that we weren't able to properly process but when returning negative values from our TimestampExtractor we enter infinite loop that breaks processing.

Here is fix for this edge case.