### PR TITLE
dispose of AdminClient when closing KafkaStream

### DIFF
--- a/core/Processors/Internal/TaskManager.cs
+++ b/core/Processors/Internal/TaskManager.cs
@@ -190,6 +190,7 @@ namespace Streamiz.Kafka.Net.Processors.Internal
             partitionsToTaskId.Clear();
             
             changelogReader.Clear();
+            adminClient.Dispose();
 
             // if one delete request is in progress, we wait the result before closing the manager
             if (currentDeleteTask is {IsCompleted: false})

--- a/core/Processors/Internal/TaskManager.cs
+++ b/core/Processors/Internal/TaskManager.cs
@@ -190,11 +190,12 @@ namespace Streamiz.Kafka.Net.Processors.Internal
             partitionsToTaskId.Clear();
             
             changelogReader.Clear();
-            adminClient.Dispose();
 
             // if one delete request is in progress, we wait the result before closing the manager
             if (currentDeleteTask is {IsCompleted: false})
                 currentDeleteTask.GetAwaiter().GetResult();
+
+            adminClient.Dispose();
         }
         
         internal int CommitAll()


### PR DESCRIPTION
We encountered problem with dangling Kafka connections  after series of starting and closing of KafkaStream. Our app is deployed as a docker container and after we  start and stop stream couple of times on it the number of alive connections increases. It is problematic because after reaching max number of alive threads in container it dies. We already increases max-limit but during more intensive periods we still were able to observe some container dying suddenly. After restart of container dangling threads disappear, but this approach requires from us to monitor and restart them manualy when they are close to reaching limit. 

When listing all running processes under container we can see that some connections are not closed even though we disposed of all running streams: 
[ps_output.txt](https://github.com/user-attachments/files/17437181/ps_output.txt)

I did some digging in our stream handling but I didn't find any KafkaStream that we forgot to dispose of.
So I started to look at Streamiz and found out that when we use constructor `public KafkaStream(Topology topology, IStreamConfig configuration)` new `DefaultKafkaClientSupplier` is created for all new streams. And I didn' t see that admin clients created for stream thread are dispose when stream is closed. After directly disposing of this client in code and checking behavior of container locally I was able to limit number of dangling connections 3 fold. 

I believe that when using default supplier this client should be disposed to clear unnecessary processes.
If you are fine with this change, could it also be included in version 1.6 as a patch? 


[There are still some threads labeled as 'Console Logger' which number increases when new KafkaStream is created but I wasn't able to find cause of this problem. If you have any idea what could cause loggers to not be able to be disposed of correctly please let me know.]
