### PR TITLE
[397] Updated MockSchemaRegistryClient with new members from Confluent.Kafka 270+

### DIFF
--- a/core/Streamiz.Kafka.Net.csproj
+++ b/core/Streamiz.Kafka.Net.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RocksDB" Version="9.4.0.50294" />
-    <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
+    <PackageReference Include="Confluent.Kafka" Version="2.8.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>

--- a/launcher/sample-stream/sample-stream.csproj
+++ b/launcher/sample-stream/sample-stream.csproj
@@ -25,8 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry.Encryption.Aws" Version="2.6.1" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry.Encryption.Aws" Version="2.8.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.8.0" />
   </ItemGroup>
 
 </Project>

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro.csproj
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.6.1" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.8.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Json/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Json.csproj
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Json/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Json.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.6.1" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.8.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Protobuf/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Protobuf.csproj
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Protobuf/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Protobuf.csproj
@@ -31,8 +31,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.6.1" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.8.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes/MockSchemaRegistryClient.cs
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes/MockSchemaRegistryClient.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Streamiz.Kafka.Net.SchemaRegistry.SerDes.Mock
@@ -23,6 +24,8 @@ namespace Streamiz.Kafka.Net.SchemaRegistry.SerDes.Mock
         private readonly Dictionary<string, List<RegisterSchema>> schemas = new();
 
         #region ISchemaRegistryClient Impl
+
+        public IWebProxy Proxy { get; }
 
         /// <summary>
         /// The maximum capacity of the local schema cache.
@@ -423,6 +426,7 @@ namespace Streamiz.Kafka.Net.SchemaRegistry.SerDes.Mock
         }
 
         public IEnumerable<KeyValuePair<string, string>> Config { get; private set; }
+        public IAuthenticationHeaderValueProvider AuthHeaderProvider { get; }
 
         #endregion ISchemaRegistryClient Impl
     }

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.csproj
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated MockSchemaRegistryClient to include new interface members from ISchemaRegistryClient from Confluent.Kafka 2.7.0+

This should fix #397