### PR TITLE
Expose message headers through ProcessorContext

### DIFF
--- a/core/Kafka/KafkaLoggerAdapter.cs
+++ b/core/Kafka/KafkaLoggerAdapter.cs
@@ -30,8 +30,11 @@ namespace Streamiz.Kafka.Net.Kafka
 
         internal void LogConsume(IConsumer<byte[], byte[]> consumer, LogMessage message)
         {
-            string logPrefix = Thread.CurrentThread.Name != null ? $"stream-thread[{Thread.CurrentThread.Name}] " : "";
-            log.LogDebug("{LogPrefix}Log consumer {ConsumerName} - {Message}", logPrefix, GetName(consumer), message.Message);
+            if (log.IsEnabled(LogLevel.Debug))
+            {
+                string logPrefix = Thread.CurrentThread.Name != null ? $"stream-thread[{Thread.CurrentThread.Name}] " : "";
+                log.LogDebug("{LogPrefix}Log consumer {ConsumerName} - {Message}", logPrefix, GetName(consumer), message.Message);
+            }
         }
 
         internal void ErrorConsume(IConsumer<byte[], byte[]> consumer, Error error)
@@ -46,13 +49,16 @@ namespace Streamiz.Kafka.Net.Kafka
 
         internal void LogProduce(IProducer<byte[], byte[]> producer, LogMessage message)
         {
-            string logPrefix = Thread.CurrentThread.Name != null ? $"stream-thread[{Thread.CurrentThread.Name}] " : "";
-            log.LogDebug("{LogPrefix}Log producer {ProducerName} - {Message}", logPrefix, GetName(producer), message.Message);
+            if (log.IsEnabled(LogLevel.Debug))
+            { 
+                string logPrefix = Thread.CurrentThread.Name != null ? $"stream-thread[{Thread.CurrentThread.Name}] " : ""; 
+                log.LogDebug("{LogPrefix}Log producer {ProducerName} - {Message}", logPrefix, GetName(producer), message.Message);
+            }
         }
 
         internal void ErrorProduce(IProducer<byte[], byte[]> producer, Error error)
         {
-            string logPrefix = Thread.CurrentThread.Name != null ? $"stream-thread[{Thread.CurrentThread.Name}] " : "";
+            string logPrefix = Thread.CurrentThread.Name != null ? $"stream-thread[{Thread.CurrentThread.Name}] " : ""; 
             log.LogError("{LogPrefix}Error producer {ProducerName} - {ErrorReason}", logPrefix, GetName(producer), error.Reason);
         }
 
@@ -68,8 +74,11 @@ namespace Streamiz.Kafka.Net.Kafka
 
         internal void LogAdmin(IAdminClient admin, LogMessage message)
         {
-            string logPrefix = Thread.CurrentThread.Name != null ? $"stream-thread[{Thread.CurrentThread.Name}] " : "";
-            log.LogDebug("{LogPrefix}Log admin {ClientName} - {Message}", logPrefix, GetName(admin), message.Message);
+            if (log.IsEnabled(LogLevel.Debug))
+            {
+                string logPrefix = Thread.CurrentThread.Name != null ? $"stream-thread[{Thread.CurrentThread.Name}] " : "";
+               log.LogDebug("{LogPrefix}Log admin {ClientName} - {Message}", logPrefix, GetName(admin), message.Message);
+            }
         }
 
         #endregion

--- a/core/ProcessorContext.cs
+++ b/core/ProcessorContext.cs
@@ -54,6 +54,11 @@ namespace Streamiz.Kafka.Net
         public long Offset => RecordContext.Offset;
 
         /// <summary>
+        /// Current message headers of record processing
+        /// </summary>
+        public Headers Headers => RecordContext.Headers;
+
+        /// <summary>
         /// Current partition of record processing
         /// </summary>
         public Partition Partition => RecordContext.Partition;

--- a/core/Processors/AbstractAsyncProcessor.cs
+++ b/core/Processors/AbstractAsyncProcessor.cs
@@ -113,13 +113,18 @@ namespace Streamiz.Kafka.Net.Processors
                 where policyException.IsInstanceOfType(innerException) 
                 select innerException).Any();
 
-        private void LogProcessingKeyValueWithRetryNumber(K key, V value, int retryNumber, bool result) => log.LogDebug(
-            $"{logPrefix}Process<{typeof(K).Name},{typeof(V).Name}> message with key {key} and {value}" +
-            $" with record metadata [topic:{Context.RecordContext.Topic}|" +
-            $"partition:{Context.RecordContext.Partition}|offset:{Context.RecordContext.Offset}] [retry.number={retryNumber}, result={(result ? "Success" : "Failure")}]");
-        
+        private void LogProcessingKeyValueWithRetryNumber(K key, V value, int retryNumber, bool result)
+        {
+            if (log.IsEnabled(LogLevel.Debug))
+            {
+                log.LogDebug(
+                    $"{logPrefix}Process<{typeof(K).Name},{typeof(V).Name}> message with key {key} and {value}" +
+                    $" with record metadata [topic:{Context.RecordContext.Topic}|" +
+                    $"partition:{Context.RecordContext.Partition}|offset:{Context.RecordContext.Offset}] [retry.number={retryNumber}, result={(result ? "Success" : "Failure")}]");
+            }
+        }
+
         public abstract Task<IEnumerable<KeyValuePair<K1, V1>>> ProcessAsync(K key, V value, Headers headers, long timestamp,
             ExternalContext context);
-        
     }
 }

--- a/core/Processors/AbstractProcessor.cs
+++ b/core/Processors/AbstractProcessor.cs
@@ -87,9 +87,12 @@ namespace Streamiz.Kafka.Net.Processors
 
         public virtual void Forward<K1, V1>(K1 key, V1 value)
         {
-            log.LogDebug(
-                "{LogPrefix}Forward<{KeyType},{ValueType}> message with key {Key} and value {Value} to each next processor",
-                logPrefix, typeof(K1).Name, typeof(V1).Name, key, value);
+            if (log.IsEnabled(LogLevel.Debug))
+            {
+                log.LogDebug(
+                    "{LogPrefix}Forward<{KeyType},{ValueType}> message with key {Key} and value {Value} to each next processor",
+                    logPrefix, typeof(K1).Name, typeof(V1).Name, key, value);
+            }
 
             Forward(Next.OfType<IProcessor<K1, V1>>(), processor => processor.Process(key, value));
         }
@@ -99,20 +102,27 @@ namespace Streamiz.Kafka.Net.Processors
             var processors = Next.OfType<IProcessor<K1, V1>>().Where(processor => processor.Name.Equals(name));
             Forward(processors, processor =>
             {
-                log.LogDebug(
-                    "{LogPrefix}Forward<{KeyType},{ValueType}> message with key {Key} and value {Value} to processor {Processor}",
-                    logPrefix,
-                    typeof(K1).Name, typeof(V1).Name, key, value, name);
+                if (log.IsEnabled(LogLevel.Debug))
+                {
+                    log.LogDebug(
+                        "{LogPrefix}Forward<{KeyType},{ValueType}> message with key {Key} and value {Value} to processor {Processor}",
+                        logPrefix,
+                        typeof(K1).Name, typeof(V1).Name, key, value, name);
+                }
+
                 processor.Process(key, value);
             });
         }
 
         public virtual void Forward(K key, V value)
         {
-            log.LogDebug(
-                "{LogPrefix}Forward<{KeyType},{ValueType}> message with key {Key} and value {Value} to each next processor",
-                logPrefix, typeof(K).Name, typeof(V).Name, key, value);
-            
+            if (log.IsEnabled(LogLevel.Debug))
+            {
+                log.LogDebug(
+                    "{LogPrefix}Forward<{KeyType},{ValueType}> message with key {Key} and value {Value} to each next processor",
+                    logPrefix, typeof(K).Name, typeof(V).Name, key, value);
+            }
+
             Forward(Next, genericProcessor =>
             {
                 if (genericProcessor is IProcessor<K, V> processor)
@@ -126,10 +136,14 @@ namespace Streamiz.Kafka.Net.Processors
         {
             Forward(Next.Where(processor => processor.Name.Equals(name)), genericProcessor =>
             {
-                log.LogDebug(
-                    "{LogPrefix}Forward<{KeyType},{ValueType}> message with key {Key} and value {Value} to processor {Processor}",
-                    logPrefix,
-                    typeof(K).Name, typeof(V).Name, key, value, name);
+                if (log.IsEnabled(LogLevel.Debug))
+                {
+                    log.LogDebug(
+                        "{LogPrefix}Forward<{KeyType},{ValueType}> message with key {Key} and value {Value} to processor {Processor}",
+                        logPrefix,
+                        typeof(K).Name, typeof(V).Name, key, value, name);
+                }
+
                 if (genericProcessor is IProcessor<K, V> processor)
                     processor.Process(key, value);
                 else
@@ -186,10 +200,16 @@ namespace Streamiz.Kafka.Net.Processors
             log.LogDebug("{LogPrefix}Process context initialized", logPrefix);
         }
 
-        protected void LogProcessingKeyValue(K key, V value) => log.LogDebug(
-            $"{logPrefix}Process<{typeof(K).Name},{typeof(V).Name}> message with key {key} and {value}" +
-            $" with record metadata [topic:{Context.RecordContext.Topic}|" +
-            $"partition:{Context.RecordContext.Partition}|offset:{Context.RecordContext.Offset}]");
+        protected void LogProcessingKeyValue(K key, V value)
+        {
+            if (log.IsEnabled(LogLevel.Debug))
+            {
+                log.LogDebug(
+                    $"{logPrefix}Process<{typeof(K).Name},{typeof(V).Name}> message with key {key} and {value}" +
+                    $" with record metadata [topic:{Context.RecordContext.Topic}|" +
+                    $"partition:{Context.RecordContext.Partition}|offset:{Context.RecordContext.Offset}]");
+            }
+        }
 
         #region Setter
 

--- a/core/Processors/Internal/GlobalStateUpdateTask.cs
+++ b/core/Processors/Internal/GlobalStateUpdateTask.cs
@@ -61,11 +61,20 @@ namespace Streamiz.Kafka.Net.Processors.Internal
 
             context.SetRecordMetaData(record);
 
-            var recordInfo = $"Topic:{record.Topic}|Partition:{record.Partition.Value}|Offset:{record.Offset}|Timestamp:{record.Message.Timestamp.UnixTimestampMs}";
-            log.LogDebug("Start processing one record [{RecordInfo}]", recordInfo);
+            string recordInfo = null;
+            if (log.IsEnabled(LogLevel.Debug))
+            {
+                recordInfo = $"Topic:{record.Topic}|Partition:{record.Partition.Value}|Offset:{record.Offset}|Timestamp:{record.Message.Timestamp.UnixTimestampMs}";
+                log.LogDebug("Start processing one record [{RecordInfo}]", recordInfo);
+            }
+          
             processor.Process(record);
-            log.LogDebug("Completed processing one record [{RecordInfo}]", recordInfo);
-            
+
+            if (log.IsEnabled(LogLevel.Debug))
+            {
+                log.LogDebug("Completed processing one record [{RecordInfo}]", recordInfo);
+            }
+
             offsets.AddOrUpdate(record.TopicPartition, record.Offset);
         }
 

--- a/test/Streamiz.Kafka.Net.Tests/Public/ProcessorContextTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Public/ProcessorContextTests.cs
@@ -49,12 +49,14 @@ namespace Streamiz.Kafka.Net.Tests.Public
             result.Partition = 0;
             result.Offset = 100;
             result.Message.Timestamp = new Timestamp(dt);
+            result.Message.Headers = new Headers();
             context.SetRecordMetaData(result);
 
             Assert.AreEqual("topic", context.Topic);
             Assert.AreEqual(0, context.Partition.Value);
             Assert.AreEqual(100, context.Offset);
             Assert.AreEqual(dt.GetMilliseconds(), context.Timestamp);
+            Assert.AreEqual(result.Message.Headers, context.Headers);
         }
 
         [Test]


### PR DESCRIPTION
1. Added Header getter to ProcessorContext access message headers from IRecordContext
2. Call debug logger only if Debug level is enabled