### PR TITLE
Allow configuration of timeout of watermark offsets request

### DIFF
--- a/core/Processors/Internal/GlobalStateManager.cs
+++ b/core/Processors/Internal/GlobalStateManager.cs
@@ -271,7 +271,7 @@ namespace Streamiz.Kafka.Net.Processors.Internal
         {
             return topicPartitions
                 .Select(tp => {
-                    var offsets = globalConsumer.QueryWatermarkOffsets(tp, TimeSpan.FromSeconds(5));
+                    var offsets = globalConsumer.QueryWatermarkOffsets(tp, config.QueryWatermarkOffsetsTimeout);
                     return new
                     {
                         TopicPartition = tp,

--- a/core/Processors/Internal/StoreChangelogReader.cs
+++ b/core/Processors/Internal/StoreChangelogReader.cs
@@ -46,6 +46,7 @@ namespace Streamiz.Kafka.Net.Processors.Internal
         private static readonly long DEFAULT_OFFSET_UPDATE_MS = (long)TimeSpan.FromMinutes(5L).TotalMilliseconds;
         private readonly long pollTimeMs;
         private readonly long maxPollRestoringRecords;
+        private readonly IStreamConfig config;
         
         public StoreChangelogReader(
             IStreamConfig config,
@@ -53,6 +54,7 @@ namespace Streamiz.Kafka.Net.Processors.Internal
             string threadId,
             StreamMetricsRegistry metricsRegistry)
         {
+            this.config = config;
             this.restoreConsumer = restoreConsumer;
             this.threadId = threadId;
             this.metricsRegistry = metricsRegistry;
@@ -331,7 +333,7 @@ namespace Streamiz.Kafka.Net.Processors.Internal
         {
             return registeredChangelogs
                 .Select(_changelog => {
-                    var offsets = restoreConsumer.QueryWatermarkOffsets(_changelog.StoreMetadata.ChangelogTopicPartition, TimeSpan.FromSeconds(5));
+                    var offsets = restoreConsumer.QueryWatermarkOffsets(_changelog.StoreMetadata.ChangelogTopicPartition, config.QueryWatermarkOffsetsTimeout);
                     return new
                     {
                         TopicPartition = _changelog.StoreMetadata.ChangelogTopicPartition,

--- a/core/StreamConfig.cs
+++ b/core/StreamConfig.cs
@@ -357,6 +357,11 @@ namespace Streamiz.Kafka.Net
 
         bool? AllowAutoCreateTopics { get; set; }
 
+        /// <summary>
+        /// Timeout for QueryWatermarkOffsets operations when restoring state stores. (Default: 5 seconds)
+        /// </summary>
+        TimeSpan QueryWatermarkOffsetsTimeout { get; set; }
+
         #endregion
         
         #region Middlewares
@@ -524,6 +529,7 @@ namespace Streamiz.Kafka.Net
         private const string productionExceptionHandlerCst = "production.exception.handler";
         private const string logProcessingSummaryCst = "log.processing.summary";
         private const string stateStoreCacheMaxBytesCst = "statestore.cache.max.bytes";
+        private const string queryWatermarkOffsetsTimeoutMsCst = "query.watermark.offsets.timeout.ms";
         
         /// <summary>
         /// Default commit interval in milliseconds when exactly once is not enabled
@@ -2489,6 +2495,7 @@ namespace Streamiz.Kafka.Net
             ParallelProcessing = false;
             MaxDegreeOfParallelism = 8;
             DefaultStateStoreCacheMaxBytes = 5 * 1024 * 1024;
+            QueryWatermarkOffsetsTimeout = TimeSpan.FromSeconds(5);
 
             _consumerConfig = new ConsumerConfig();
             _producerConfig = new ProducerConfig();
@@ -3015,6 +3022,16 @@ namespace Streamiz.Kafka.Net
         {
             get => configProperties[stateStoreCacheMaxBytesCst];
             set => configProperties.AddOrUpdate(stateStoreCacheMaxBytesCst, value);
+        }
+
+        /// <summary>
+        /// Timeout for QueryWatermarkOffsets operations when restoring state stores. (Default: 5 seconds)
+        /// </summary>
+        [StreamConfigProperty("" + queryWatermarkOffsetsTimeoutMsCst)]
+        public TimeSpan QueryWatermarkOffsetsTimeout
+        {
+            get => configProperties[queryWatermarkOffsetsTimeoutMsCst];
+            set => configProperties.AddOrUpdate(queryWatermarkOffsetsTimeoutMsCst, value);
         }
 
         /// <summary>


### PR DESCRIPTION
Hey @LGouellec
 
Add configurable timeout for QueryWatermarkOffsets operations

## Problem
During testing of our Kafka Streams application, we encountered intermittent timeout exceptions during stream initialization that cause test failures. The current hardcoded 5-second timeout for QueryWatermarkOffsets operations is insufficient in environments with high load or network latency.

## Solution
Added a new `QueryWatermarkOffsetsTimeout` property to `IStreamConfig` that allows users to configure the timeout value based on their environment requirements.

## Changes
- Added `QueryWatermarkOffsetsTimeout` property to `IStreamConfig` interface
- Updated `StreamConfig` class with the new configuration property (default: 5 seconds)
- Modified `StoreChangelogReader` and `GlobalStateManager` to use the configurable timeout instead of hardcoded values
