### PR TITLE
Issue/468 - Fix infinite RESTORING when changelog buffer has past-end records

### DIFF
--- a/core/Processors/Internal/StoreChangelogReader.cs
+++ b/core/Processors/Internal/StoreChangelogReader.cs
@@ -199,11 +199,12 @@ namespace Streamiz.Kafka.Net.Processors.Internal
 
             if (numRecords > 0)
             {
-                var records = changelogMetadata.BufferedRecords.Take(numRecords);
+                // Match Apache Kafka Streams: restore a prefix, then remove it from the buffer.
+                // Take()+Clear-only-when-all previously left past-end records in the buffer and
+                // HasRestoredToEnd returned false forever (infinite RESTORING). See #468.
+                var records = changelogMetadata.BufferedRecords.GetRange(0, numRecords);
                 changelogMetadata.StateManager.Restore(changelogMetadata.StoreMetadata, records);
-                
-                if (numRecords >= changelogMetadata.BufferedRecords.Count)
-                    changelogMetadata.BufferedRecords.Clear();
+                changelogMetadata.BufferedRecords.RemoveRange(0, numRecords);
 
                 long currentOffset = changelogMetadata.StoreMetadata.Offset.Value;
                 changelogMetadata.CurrentOffset = currentOffset;
@@ -275,7 +276,9 @@ namespace Streamiz.Kafka.Net.Processors.Internal
                 return offset != Offset.Unset && offset >= endOffset;
             }
 
-            return false;
+            // Past-end records may remain buffered (written after the end-offset snapshot).
+            // Apache Streams: complete when the first remaining buffered offset is already at/past end.
+            return changelogMetadata.BufferedRecords[0].Offset >= endOffset;
         }
 
         private void BufferedRecords(IEnumerable<ConsumeResult<byte[], byte[]>> records)
@@ -290,7 +293,8 @@ namespace Streamiz.Kafka.Net.Processors.Internal
                 else
                 {
                     metadata.BufferedRecords.Add(record);
-                    if (metadata.RestoreEndOffset == null || record.Offset <= metadata.RestoreEndOffset.Value)
+                    // Exclusive end offset (High watermark), same as Apache Kafka Streams.
+                    if (metadata.RestoreEndOffset == null || record.Offset < metadata.RestoreEndOffset.Value)
                         metadata.BufferedLimit = metadata.BufferedRecords.Count;
                 }
             }

--- a/test/Streamiz.Kafka.Net.Tests/Private/StoreChangelogReaderTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Private/StoreChangelogReaderTests.cs
@@ -259,5 +259,32 @@ namespace Streamiz.Kafka.Net.Tests.Private
             
           Assert.IsTrue(storeChangelogReader.HasRestoredToEnd(metadata));
         }
+
+        [Test]
+        public void HasRestoredToEnd_WhenBufferedPastEndOffset_ReturnsTrue()
+        {
+            // Records written after the end-offset snapshot must not block completion (#468).
+            var metadata = new ChangelogMetadata
+            {
+                RestoreEndOffset = 100,
+                CurrentOffset = 99,
+                BufferedRecords = new List<ConsumeResult<byte[], byte[]>>
+                {
+                    new ConsumeResult<byte[], byte[]>
+                    {
+                        Topic = changelogTopic,
+                        Partition = 0,
+                        Offset = 101,
+                        Message = new Message<byte[], byte[]> { Key = new byte[] { 1 }, Value = new byte[] { 2 } }
+                    }
+                },
+                StoreMetadata = new ProcessorStateManager.StateStoreMetadata
+                {
+                    ChangelogTopicPartition = new TopicPartition(changelogTopic, 0)
+                }
+            };
+
+            Assert.IsTrue(storeChangelogReader.HasRestoredToEnd(metadata));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #468: `StoreChangelogReader` could leave tasks stuck in `RESTORING` forever when the restore buffer retained changelog records past the snapshotted end offset.

This is **not** the same bug as #463 / #464 (empty changelog `beginOffset == endOffset`). Here the changelog has data; past-end records left in `BufferedRecords` made `HasRestoredToEnd` return `false` indefinitely.

## Changes

Align with Apache Kafka Streams [`StoreChangelogReader.java`](https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java):

1. Always remove the restored prefix (`GetRange` + `RemoveRange`) instead of `Take` + Clear-only-when-all — see [restoreChangelog](https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java#L695-L716).
2. When the buffer is non-empty, complete if the first buffered offset is already ≥ end — see [hasRestoredToEnd](https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java#L290-L328) (L327).
3. Use exclusive end for the buffer limit (`offset < RestoreEndOffset`) — see [bufferChangelogRecords](https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java#L672-L687) (L682).

Adds a unit test for past-end buffered records.
